### PR TITLE
[#43] Set `-target` scalac option to 1.7 for scala 2.10 and 2.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,8 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-
+.bloop/*
+.metals/*
+project/.bloop/*
 # End of https://www.gitignore.io/api/osx,sbt,java,linux,maven,scala,windows,intellij
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,12 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+        <option name="SMART_TABS" value="true" />
+      </value>
+    </option>
     <DBN-PSQL>
       <case-options enabled="false">
         <option name="KEYWORD_CASE" value="lower" />
@@ -24,5 +31,11 @@
         <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
       </formatting-settings>
     </DBN-SQL>
+    <MarkdownNavigatorCodeStyleSettings>
+      <option name="RIGHT_MARGIN" value="72" />
+    </MarkdownNavigatorCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="USE_SCALADOC2_FORMATTING" value="true" />
+    </ScalaCodeStyleSettings>
   </code_scheme>
 </component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+jdk: openjdk8
 script:
   if [[ ! -z "$TRAVIS_TAG" ]]; then ./publish.sh; else ./make.sh; fi
 sudo: false

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Table of contents
   - [Artifacts](#artifacts)
   - [Background](#background)
   - [Architecture](#architecture)
+  - [JVM compatibility](#jvm-compatibility)
 - [Installation](#installation)
 - [Usage](#usage)
 - [Configuration](#configuration)
@@ -180,6 +181,19 @@ utilities object `AvroSingleObjectEncodingUtils` exposes some generic purpose fu
 - remove the header (schema ID included) of a single-object encoded byte array
 
 ![Darwin interaction](docs/img/darwin_interaction.jpg)
+
+JVM compatibility
+-------------
+Darwin is cross-published among different scala versions (2.10, 2.11, 2.12).
+Depending on the Scala version, it targets different JVM versions.
+
+Please refer to the following compatibility matrix:
+
+| Scala version | JVM version |
+|---------------|-------------|
+| 2.10 | 1.7 |
+| 2.11 | 1.7 |
+| 2.12 | 1.8 |
 
 Installation
 -------------

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -21,16 +21,15 @@ object Settings {
       "-Ywarn-dead-code",
       "-Ywarn-inaccessible",
       "-Xlint",
-      "-target:jvm-1.8",
       "-encoding", "UTF-8"
     ) ++ {
       CrossVersion.partialVersion(scalaVersion) match {
         case SCALA_210 =>
-          Nil
+          Seq("-target:jvm-1.7")
         case SCALA_211 =>
-          Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-infer-any")
+          Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-infer-any", "-target:jvm-1.7")
         case SCALA_212 =>
-          Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-infer-any")
+          Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-infer-any", "-target:jvm-1.8")
         case version: Option[(Long, Long)] =>
           throw new Exception(s"Unknown scala version: $version")
       }
@@ -54,7 +53,7 @@ object Settings {
     homepage := Some(url("https://github.com/agile-lab-dev/darwin")),
     description := "Avro Schema Evolution made easy",
     scalacOptions ++= scalacOptionsVersion(scalaVersion.value),
-    scalacOptions.in(Compile, doc) ++= scalaDocOptionsVersion(scalaVersion.value),
+    scalacOptions.in(Compile, doc) ++= scalaDocOptionsVersion(scalaVersion.value)
   )
 
   val clouderaHadoopReleaseRepo = "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"


### PR DESCRIPTION
- Now 2.10 and 2.11 artifacts are compatible with java 7 while 2.12 are
 compatible with java 8 onwards
- Add JVM compatibility section into README.md
- Remove local IJ codestyles commited by mistake
- update .gitignore to ignore metals and bloop local files
- add jdk: openjdk8 to travis otherwise build fails