### PR TITLE
Darwin does not work in Java 7

### DIFF
--- a/common/src/main/scala/it/agilelab/darwin/common/DarwinConcurrentHashMap.scala
+++ b/common/src/main/scala/it/agilelab/darwin/common/DarwinConcurrentHashMap.scala
@@ -1,0 +1,54 @@
+package it.agilelab.darwin.common
+
+import java.util.function.{Function => JFunction}
+
+import scala.collection.concurrent.TrieMap
+
+/** A thread safe lock-free concurrent map that exposes only getOrElseUpdate and getOrElse methods
+  * It is backed by either a scala.collection.concurrent.TrieMap or java.util.concurrent.ConcurrentHashMap
+  * depending on the JVM that executes Darwin.
+  * JVM 8 or later use java's ConcurrentHashMap while earlier versions use scala's TrieMap
+  *
+  * Obtain the "correct" instance using {{{DarwinConcurrentHashMap.empty}}} factory method.
+  * */
+trait DarwinConcurrentHashMap[K, V] {
+  def getOrElseUpdate(k: K, newValue: => V): V
+
+  def getOrElse(k: K, default: => V): V
+}
+
+object DarwinConcurrentHashMap {
+
+  private class DarwinJava8ConcurrentHashMap[K, V] extends DarwinConcurrentHashMap[K, V] {
+    private val innerMap = new java.util.concurrent.ConcurrentHashMap[K, V]()
+
+    override def getOrElseUpdate(k: K, newValue: => V): V = {
+      innerMap.computeIfAbsent(k, new JFunction[K, V]() {
+        override def apply(t: K): V = newValue
+      })
+    }
+
+    override def getOrElse(k: K, default: => V): V = {
+      innerMap.getOrDefault(k, default)
+    }
+  }
+
+  private class DarwinTrieConcurrentHashMap[K, V] extends DarwinConcurrentHashMap[K, V] {
+    private val innerMap = TrieMap.empty[K, V]
+
+    override def getOrElseUpdate(k: K, newValue: => V): V = innerMap.getOrElseUpdate(k, newValue)
+
+    override def getOrElse(k: K, default: => V): V = innerMap.getOrElse(k, default)
+  }
+
+
+  private val isJavaAtLeast8 = JavaVersion.current() >= 8
+
+  def empty[K, V]: DarwinConcurrentHashMap[K, V] = {
+    if (isJavaAtLeast8) {
+      new DarwinJava8ConcurrentHashMap()
+    } else {
+      new DarwinTrieConcurrentHashMap()
+    }
+  }
+}

--- a/common/src/main/scala/it/agilelab/darwin/common/JavaVersion.scala
+++ b/common/src/main/scala/it/agilelab/darwin/common/JavaVersion.scala
@@ -1,0 +1,24 @@
+package it.agilelab.darwin.common
+
+object JavaVersion {
+
+  /**
+    * @return the JVM version in use, It returns an Integer indicating the major version i
+    */
+  def current(): Int = {
+    val propertyValue = System.getProperty("java.version")
+    parseJavaVersion(propertyValue)
+  }
+
+  /**
+    * @return the JVM version represented by the input string, It returns an Integer indicating the major version i
+    */
+  def parseJavaVersion(propertyValue: String): Int = {
+    val splits = propertyValue.split("\\.")
+    if (propertyValue.startsWith("1.")) {
+      splits(1).toInt
+    } else {
+      splits(0).toInt
+    }
+  }
+}

--- a/common/src/test/scala/it/agilelab/darwin/common/DarwinConcurrentHashMapSpec.scala
+++ b/common/src/test/scala/it/agilelab/darwin/common/DarwinConcurrentHashMapSpec.scala
@@ -1,0 +1,59 @@
+package it.agilelab.darwin.common
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class DarwinConcurrentHashMapSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  private val realJavaVersion = System.getProperty("java.version")
+
+  after {
+    System.setProperty("java.version", realJavaVersion)
+  }
+
+  def test(): Unit = {
+    val threadNumber = 1000
+    val map = DarwinConcurrentHashMap.empty[String, Int]
+    var counter = 0
+    val threadCounter = new AtomicInteger(0)
+    val runnables = for (_ <- 1 to threadNumber) yield {
+      new Runnable {
+        override def run(): Unit = {
+          threadCounter.incrementAndGet()
+          val res = map.getOrElseUpdate("A", {
+            counter += 1
+            counter
+          })
+          res should be(1)
+        }
+      }
+    }
+    val threads = for (r <- runnables) yield {
+      val t = new Thread(r)
+      t
+    }
+    for (t <- threads) {
+      t.start()
+    }
+    for (t <- threads) {
+      t.join()
+    }
+    threadCounter.get() should be(threadNumber)
+  }
+
+
+  it should "not evaluate the value if the key is present JAVA 8" in {
+    test()
+  }
+
+  it should "not evaluate the value if the key is present JAVA 7" in {
+    if (JavaVersion.parseJavaVersion(realJavaVersion) >= 8) {
+      System.setProperty("java.version", "1.7")
+      test()
+    } else {
+      assert(true)
+    }
+  }
+
+
+}

--- a/core/src/main/scala/it/agilelab/darwin/manager/AvroSchemaManagerFactory.scala
+++ b/core/src/main/scala/it/agilelab/darwin/manager/AvroSchemaManagerFactory.scala
@@ -1,12 +1,9 @@
 package it.agilelab.darwin.manager
 
-import java.util.concurrent.ConcurrentHashMap
-
 import com.typesafe.config.Config
-import it.agilelab.darwin.common.{ConnectorFactory, Logging}
+import it.agilelab.darwin.common.{ConnectorFactory, DarwinConcurrentHashMap, Logging}
 import it.agilelab.darwin.manager.exception.ConnectorNotFoundException
 import it.agilelab.darwin.manager.util.{ConfigUtil, ConfigurationKeys}
-import java.util.function.{Function => JFunction}
 
 /**
   * Factory used to obtain the desired implementation of AvroSchemaManager.
@@ -16,8 +13,8 @@ import java.util.function.{Function => JFunction}
   */
 object AvroSchemaManagerFactory extends Logging {
 
-  private val _instancePool: ConcurrentHashMap[String, AvroSchemaManager] =
-    new ConcurrentHashMap[String, AvroSchemaManager]
+  private val _instancePool: DarwinConcurrentHashMap[String, AvroSchemaManager] =
+    DarwinConcurrentHashMap.empty[String, AvroSchemaManager]
 
   private def configKey(c: Config): String = {
     ConfigUtil.printConfig(c)
@@ -31,26 +28,24 @@ object AvroSchemaManagerFactory extends Logging {
     */
   @throws[ConnectorNotFoundException]
   def initialize(config: Config): AvroSchemaManager = {
-
-    val mappingFunc = new JFunction[String, AvroSchemaManager] {
-      override def apply(t: String): AvroSchemaManager = {
-        log.debug("creating instance of AvroSchemaManager")
-        val endianness = ConfigUtil.stringToEndianness(config.getString(ConfigurationKeys.ENDIANNESS))
-        val result = config.getString(ConfigurationKeys.MANAGER_TYPE) match {
-          case ConfigurationKeys.CACHED_EAGER =>
-            new CachedEagerAvroSchemaManager(ConnectorFactory.connector(config), endianness)
-          case ConfigurationKeys.CACHED_LAZY =>
-            new CachedLazyAvroSchemaManager(ConnectorFactory.connector(config), endianness)
-          case ConfigurationKeys.LAZY =>
-            new LazyAvroSchemaManager(ConnectorFactory.connector(config), endianness)
-          case _ => throw new IllegalArgumentException(s"No valid manager can be created for" +
-            s" ${ConfigurationKeys.MANAGER_TYPE} key ${config.getString(ConfigurationKeys.MANAGER_TYPE)}")
-        }
-        log.debug("AvroSchemaManager instance created")
-        result
+    val key = configKey(config)
+    lazy val mappingFunc = {
+      log.debug("creating instance of AvroSchemaManager")
+      val endianness = ConfigUtil.stringToEndianness(config.getString(ConfigurationKeys.ENDIANNESS))
+      val result = config.getString(ConfigurationKeys.MANAGER_TYPE) match {
+        case ConfigurationKeys.CACHED_EAGER =>
+          new CachedEagerAvroSchemaManager(ConnectorFactory.connector(config), endianness)
+        case ConfigurationKeys.CACHED_LAZY =>
+          new CachedLazyAvroSchemaManager(ConnectorFactory.connector(config), endianness)
+        case ConfigurationKeys.LAZY =>
+          new LazyAvroSchemaManager(ConnectorFactory.connector(config), endianness)
+        case _ => throw new IllegalArgumentException(s"No valid manager can be created for" +
+          s" ${ConfigurationKeys.MANAGER_TYPE} key ${config.getString(ConfigurationKeys.MANAGER_TYPE)}")
       }
+      log.debug("AvroSchemaManager instance created")
+      result
     }
-    _instancePool.computeIfAbsent(configKey(config), mappingFunc)
+    _instancePool.getOrElseUpdate(key, mappingFunc)
   }
 
   /**
@@ -60,7 +55,7 @@ object AvroSchemaManagerFactory extends Logging {
     * @return the initialized instance of AvroSchemaManager
     */
   def getInstance(config: Config): AvroSchemaManager = {
-    Option(_instancePool.get(configKey(config))).getOrElse(
+    _instancePool.getOrElse(configKey(config),
       throw new IllegalArgumentException(s"No valid manager can be found for" +
         s" ${ConfigurationKeys.MANAGER_TYPE} key ${config.getString(ConfigurationKeys.MANAGER_TYPE)}")
     )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -46,12 +46,26 @@ object Settings {
     }
   }
 
+  def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+    CrossVersion.partialVersion(scalaVersion) match {
+      case SCALA_210 =>
+        Seq("-source", "1.7", "-target", "1.7")
+      case SCALA_211 =>
+        Seq("-source", "1.7", "-target", "1.7")
+      case SCALA_212 =>
+        Seq("-source", "1.8", "-target", "1.8")
+      case version: Option[(Long, Long)] =>
+        throw new Exception(s"Unknown scala version: $version")
+    }
+  }
+
 
   lazy val projectSettings = Seq(
     organization := "it.agilelab",
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
     homepage := Some(url("https://github.com/agile-lab-dev/darwin")),
     description := "Avro Schema Evolution made easy",
+    javacOptions ++= javacOptionsVersion(scalaVersion.value),
     scalacOptions ++= scalacOptionsVersion(scalaVersion.value),
     scalacOptions.in(Compile, doc) ++= scalaDocOptionsVersion(scalaVersion.value)
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.2.8


### PR DESCRIPTION
DarwinConcurrentHashMap is a thread safe lock-free concurrent map that
exposes only getOrElseUpdate and getOrElse methods.
It is backed by either a scala.collection.concurrent.TrieMap or
java.util.concurrent.ConcurrentHashMap depending on the JVM that executes
Darwin.
JVM 8 or later use java's ConcurrentHashMap while earlier versions use scala's TrieMap

Obtain the "correct" instance using {{{DarwinConcurrentHashMap.empty}}}
factory method.