### PR TITLE
[#67] AvroSingleObjectEncodingUtils getId wants unused ByteOrder

### DIFF
--- a/common/src/main/scala/it/agilelab/darwin/manager/util/AvroSingleObjectEncodingUtils.scala
+++ b/common/src/main/scala/it/agilelab/darwin/manager/util/AvroSingleObjectEncodingUtils.scala
@@ -14,7 +14,7 @@ object AvroSingleObjectEncodingUtils {
   private val ID_SIZE = 8
   private val HEADER_LENGTH = V1_HEADER.length + ID_SIZE
 
-  private val schemaMap = DarwinConcurrentHashMap.empty[Schema, (Long, Array[Byte])]
+  private val schemaMap = DarwinConcurrentHashMap.empty[Schema, Long]
 
   /** Exception that can be thrown if the data is not single-object encoded
     */
@@ -234,17 +234,10 @@ object AvroSingleObjectEncodingUtils {
     * Extracts the ID from a Schema.
     *
     * @param schema     a Schema with unknown ID
-    * @param endianness the endianness that will be used to read fingerprint bytes,
-    *                   it won't affect how avro payload is read, that is up to the darwin user
     * @return the ID associated with the input schema
     */
-  def getId(schema: Schema, endianness: ByteOrder): Long = {
-    schemaMap.getOrElseUpdate(schema,
-      {
-        val f = SchemaNormalization.parsingFingerprint64(schema)
-        (f, f.longToByteArray(endianness))
-      }
-    )._1
+  def getId(schema: Schema): Long = {
+    schemaMap.getOrElseUpdate(schema, SchemaNormalization.parsingFingerprint64(schema))
   }
 
   /** Converts a byte array into its hexadecimal string representation

--- a/common/src/test/scala/it/agilelab/darwin/manager/util/AvroSingleObjectEncodingUtilsSpec.scala
+++ b/common/src/test/scala/it/agilelab/darwin/manager/util/AvroSingleObjectEncodingUtilsSpec.scala
@@ -20,6 +20,7 @@ abstract class AvroSingleObjectEncodingUtilsSpec(val endianness: ByteOrder) exte
   val testId = 4560514203639509981L
   val parser = new Schema.Parser()
 
+
   val schema = parser.parse(
     """{
       |     "type": "record",
@@ -177,7 +178,7 @@ abstract class AvroSingleObjectEncodingUtilsSpec(val endianness: ByteOrder) exte
 
   "getId" should "return the testId" in {
 
-    AvroSingleObjectEncodingUtils.getId(schema, endianness) should be(testId)
+    AvroSingleObjectEncodingUtils.getId(schema) should be(testId)
   }
 
 
@@ -190,7 +191,7 @@ abstract class AvroSingleObjectEncodingUtilsSpec(val endianness: ByteOrder) exte
     val encoder = EncoderFactory.get.binaryEncoder(stream, null)
     val writer = new GenericDatumWriter[GenericRecord](schema)
     AvroSingleObjectEncodingUtils
-      .generateAvroSingleObjectEncoded(stream, AvroSingleObjectEncodingUtils.getId(schema, endianness), endianness) {
+      .generateAvroSingleObjectEncoded(stream, AvroSingleObjectEncodingUtils.getId(schema), endianness) {
         os =>
           writer.write(record, encoder)
           writer.write(record, encoder)
@@ -221,7 +222,7 @@ abstract class AvroSingleObjectEncodingUtilsSpec(val endianness: ByteOrder) exte
     val encoder = EncoderFactory.get.binaryEncoder(stream, null)
     val writer = new GenericDatumWriter[GenericRecord](schema)
     AvroSingleObjectEncodingUtils.generateAvroSingleObjectEncoded(stream,
-      AvroSingleObjectEncodingUtils.getId(schema, endianness), endianness) { os =>
+      AvroSingleObjectEncodingUtils.getId(schema), endianness) { os =>
       writer.write(record, encoder)
       writer.write(record, encoder)
       os

--- a/core/src/main/scala/it/agilelab/darwin/manager/AvroSchemaManager.scala
+++ b/core/src/main/scala/it/agilelab/darwin/manager/AvroSchemaManager.scala
@@ -36,7 +36,7 @@ abstract class AvroSchemaManager(connector: Connector, endianness: ByteOrder) ex
     * @param schema a Schema with unknown ID
     * @return the ID associated with the input schema
     */
-  def getId(schema: Schema): Long = AvroSingleObjectEncodingUtils.getId(schema, endianness)
+  def getId(schema: Schema): Long = AvroSingleObjectEncodingUtils.getId(schema)
 
   /**
     * Extracts the Schema from its ID.


### PR DESCRIPTION
 ### Changes

* `AvroSingleObjectEncodingUtils.schemaMap` now only stores the schema id Long notation
* `AvroSingleObjectEncodingUtils.getId` does not receive a `ByteOrder` anymore and does not compute the schema id byte array notation