### PR TITLE
[#70] RightBiasedEither.rightMap does not work with Left

### DIFF
--- a/common/src/main/scala/it/agilelab/darwin/common/compat/package.scala
+++ b/common/src/main/scala/it/agilelab/darwin/common/compat/package.scala
@@ -58,11 +58,11 @@ package object compat {
     }
   }
 
-  implicit class RightBiasedEither[+L, +R](self: Either[L, R]) {
+  implicit class RightBiasedEither[+L, +R](val self: Either[L, R]) extends AnyVal {
     def rightMap[R1](f: R => R1): Either[L, R1] = {
       self match {
         case Right(v) => Right(f(v))
-        case _        => this.asInstanceOf[Either[L, R1]]
+        case _        => self.asInstanceOf[Either[L, R1]]
       }
     }
   }

--- a/common/src/test/scala/it/agilelab/darwin/common/CompatSpec.scala
+++ b/common/src/test/scala/it/agilelab/darwin/common/CompatSpec.scala
@@ -1,0 +1,20 @@
+package it.agilelab.darwin.common
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import compat._
+
+class CompatSpec extends AnyFlatSpec with Matchers {
+
+  "RightBiasedEither" should "map correctly on left side" in {
+    Left[Int, String](3).rightMap {
+      "Hello" + _
+    } shouldBe Left[Int, String](3)
+  }
+
+  it should "map correctly on right side" in {
+    Right[Int, String]("Darwin").rightMap {
+      "Hello " + _
+    } shouldBe Right[Int, String]("Hello Darwin")
+  }
+}


### PR DESCRIPTION
Changes:

- add test about rightMap
- fix cast, instead of casting the implicit class, we cast the target of the implicit conversion